### PR TITLE
fix(rust): no entry found for key

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -71,7 +71,7 @@ fn extract_user_info(entry: &Value) -> Option<UserInfo> {
     entry["content"]["itemContent"]["user_results"]["result"]
         ["legacy"]
         .as_object()
-        .map(|user| {
+        .and_then(|user| {
             let username = user["screen_name"]
                 .as_str()
                 .unwrap_or("")
@@ -83,8 +83,9 @@ fn extract_user_info(entry: &Value) -> Option<UserInfo> {
                 .to_string();
             profile_image_url =
                 profile_image_url.replace("_normal", "");
-            let is_mutual = user["followed_by"]
-                .as_bool()
+            let is_mutual = user
+                .get("followed_by")
+                .and_then(|x| x.as_bool())
                 .unwrap_or(false)
                 && user["following"].as_bool().unwrap_or(false);
 
@@ -97,7 +98,6 @@ fn extract_user_info(entry: &Value) -> Option<UserInfo> {
                 None
             }
         })
-        .flatten()
 }
 
 fn find_all_entries(instructions: &[Value]) -> Vec<Value> {


### PR DESCRIPTION
Hi, awesome tool you've made here c:

I tried running the rust variant and got the following error:
```sh
amelia@heart ~/d/c/f/rust (master) [101]> cargo run -- ../test/Followers1 --folder ../output
   Compiling fetch-moots v0.1.0 (/home/amelia/dev/clones/fetch-moots/rust)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.73s
     Running `target/debug/fetch-moots ../test/Followers1 --folder ../output`
thread 'main' panicked at src/main.rs:62:33:
no entry found for key
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This pr addresses this error for me.
Thanks!